### PR TITLE
add inheritance to getting properties for class

### DIFF
--- a/RMMapper/RMMapper.m
+++ b/RMMapper/RMMapper.m
@@ -78,6 +78,10 @@ static const char *getPropertyType(objc_property_t property) {
     }
     free(properties);
     
+    // for  inheritance
+    if ([cls superclass] != [NSObject class])
+        [results addEntriesFromDictionary:[self propertiesForClass:[cls superclass]]];
+    
     // returning a copy here to make sure the dictionary is immutable
     return [NSDictionary dictionaryWithDictionary:results];
 }


### PR DESCRIPTION
Hi! It's me again. Today I encountered a problem, that method: 

``` objc
+ (NSDictionary *)propertiesForClass:(Class)cls
```

returns properties only for current class, wthout inheritance.

I spend for about 5 hours to understand, why my object saves to nsuserdefaults not fully.
I added some recursion for superclasses of current class before NSObject in objects hierarchy.
