### PR TITLE
change id to instancetype in initWithCoder

### DIFF
--- a/RMMapper/NSObject+RMArchivable.m
+++ b/RMMapper/NSObject+RMArchivable.m
@@ -30,7 +30,7 @@
     }
 }
 
-- (id)initWithCoder:(NSCoder *)decoder {
+- (instancetype)initWithCoder:(NSCoder *)decoder {
     if([self init]) {
         // Decode properties, other class vars
         NSDictionary* propertyDict = [RMMapper propertiesForClass:[self class]];


### PR DESCRIPTION
Hi! It's me again.
Today when i want to debug my app, i print:
po myObject

and get error:
error: instance method 'initWithCoder:' has incompatible result types in different translation units ('id' vs. 'NSObject *')
note: instance method 'initWithCoder:' also declared here
error: 1 errors parsing expression

And i understand your mistake in initWitCoder in NSObject+RMArchivable and fix.
