### PR TITLE
Mapping boolean values

### DIFF
--- a/RMMapper/RMMapper.m
+++ b/RMMapper/RMMapper.m
@@ -180,8 +180,13 @@ static const char *getPropertyType(objc_property_t property) {
         // Else, set value for key
         else {
             // If the value is basic type and is not array, parse it directly to obj
+            // http://stackoverflow.com/questions/3663266/kvc-string-conversion-not-working-for-bool-value
             if (![value isKindOfClass:[NSArray class]]) {
-                [obj setValue:value forKey:property];
+                @try{ [obj setValue:value forKey:property];
+                }@catch(NSException * e){ // catch the exception if the value is a boolean
+                    if ([e.name isEqualToString:NSInvalidArgumentException])
+                        [obj setValue:@([value intValue]) forKey:property];
+                }
             }
             
             // If property is NSArray or NSMutableArray, and if user provides


### PR DESCRIPTION
// http://stackoverflow.com/questions/3663266/kvc-string-conversion-not-working-for-bool-value

The mapper fails raising a exception `[__NSCFString charValue]: unrecognized selector sent to instance` when I receive a JSON with bool values. In this case redeemed property

                "order": {
                    "id": "566",
                    "code": "2704-1428417595",
                    "redeemed": "1",
                    "purchased_date": "2015-04-07 14:39:55",
                    "expiry_date": "2015-05-30 00:00:00",
                    "amount": "0.00",
                    "transaction": "iOS-1428417595"
                }