### PR TITLE
Guards against setValue forKey crashes.

### DIFF
--- a/RMMapper/NSObject+RMArchivable.m
+++ b/RMMapper/NSObject+RMArchivable.m
@@ -45,7 +45,12 @@
         for (NSString* key in propertyDict) {
             if (!excludedProperties || ![excludedProperties containsObject:key]) {
                 id value = [decoder decodeObjectForKey:key];
-                [self setValue:value forKey:key];
+                @try {
+                    [self setValue:value forKey:key];
+                }
+                @catch (NSException * e) {
+                    NSLog(@"Exception: %@", e);
+                }
             }
         }
     }


### PR DESCRIPTION
When an object changes schema between having been serialized (on app update for instance), if we've added _Nonnull properties, when we use Swift, we end up with a Fatal Exception: NSInvalidArgumentException [ setNilValueForKey]: could not set nil as the value for the key ..." that cannot be caught at Swift level.
Wrapping the setValue forKey in @try @catch  allows catching the error without breaking the app.